### PR TITLE
Show uploaded image after upload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 build
+dist

--- a/src/components/MemeUploader.jsx
+++ b/src/components/MemeUploader.jsx
@@ -4,12 +4,19 @@ import { supabase } from '../supabaseClient';
 export default function MemeUploader() {
   const [file, setFile] = useState(null);
   const [uploading, setUploading] = useState(false);
+  const [uploadedUrl, setUploadedUrl] = useState('');
 
   const uploadMeme = async () => {
     if (!file) return;
     setUploading(true);
     const filePath = `${Date.now()}_${file.name}`;
     let { error } = await supabase.storage.from('memes').upload(filePath, file);
+    if (!error) {
+      const { data } = supabase.storage
+        .from('memes')
+        .getPublicUrl(filePath);
+      setUploadedUrl(data.publicUrl);
+    }
     setUploading(false);
     if (error) return alert('Upload failed');
     alert('Meme uploaded!');
@@ -21,6 +28,15 @@ export default function MemeUploader() {
       <button className="retro-button" onClick={uploadMeme} disabled={uploading}>
         {uploading ? 'Uploading...' : 'Upload Meme'}
       </button>
+      {uploadedUrl && (
+        <div style={{ marginTop: '1rem' }}>
+          <img
+            src={uploadedUrl}
+            alt="Uploaded meme"
+            style={{ width: '200px', border: '3px solid #39ff14', borderRadius: '8px' }}
+          />
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- display the uploaded meme after it finishes uploading
- ignore build artefacts in `.gitignore`
- revert accidental package lock changes

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6889251651208326a7927322a98d85f1