### PR TITLE
feat: load Supabase config from env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+VITE_SUPABASE_URL=your_supabase_url
+VITE_SUPABASE_ANON_KEY=your_supabase_anon_key

--- a/.env.local
+++ b/.env.local
@@ -1,2 +1,0 @@
-NEXT_PUBLIC_SUPABASE_URL=your_supabase_url
-NEXT_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 node_modules
 build
+dist
+.env
+.env.local

--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+# Thememes.net
+
+## Environment Variables
+
+Create a `.env` file in the project root with the following values:
+
+```
+VITE_SUPABASE_URL=your_supabase_url
+VITE_SUPABASE_ANON_KEY=your_supabase_anon_key
+```
+
+These variables are loaded by Vite at build time and available via `import.meta.env`.
+
+Run the development server with:
+
+```
+npm run dev
+```
+
+Build the project with:
+
+```
+npm run build
+```

--- a/src/supabaseClient.js
+++ b/src/supabaseClient.js
@@ -1,6 +1,6 @@
 import { createClient } from '@supabase/supabase-js';
 
-const supabaseUrl = 'https://hdjxlibduxqahvwarxma.supabase.co';
-const supabaseAnonKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImhkanhsaWJkdXhxYWh2d2FyeG1hIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTM2MzIwMzMsImV4cCI6MjA2OTIwODAzM30.-dqgtJNkmOzpQmSw5RJDKk0mljGVyAECpsSZgnAxOnY';
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
 
 export const supabase = createClient(supabaseUrl, supabaseAnonKey);

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,6 +1,9 @@
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 import react from '@vitejs/plugin-react';
 
-export default defineConfig({
-  plugins: [react()],
+export default defineConfig(({ mode }) => {
+  loadEnv(mode, process.cwd(), '');
+  return {
+    plugins: [react()],
+  };
 });


### PR DESCRIPTION
## Summary
- read Supabase credentials from Vite environment variables
- load `.env` files at build time
- document required environment variables

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Parse error in src/components/MemeUploader.js)*

------
https://chatgpt.com/codex/tasks/task_e_68a1e6b3a3848326b074b19201138908